### PR TITLE
fix/error_event

### DIFF
--- a/ovos_plugin_mpv/__init__.py
+++ b/ovos_plugin_mpv/__init__.py
@@ -46,7 +46,7 @@ class OVOSMPVService(AudioBackend):
     def handle_track_end(self, key, val):
         if val is None:
             self._started.clear()
-            # NOTE: a event is used otherwise we block the MPV thread with self._started.wait()
+            # NOTE: a bus event is used otherwise we block the MPV monitor thread with self._started.wait()
             self.bus.emit(Message("ovos.mpv.timeout_check"))
             return
         if val is False:
@@ -193,12 +193,3 @@ MPVAudioPluginConfig = {
         "active": True
     }
 }
-
-if __name__ == "__main__":
-    from ovos_utils.fakebus import FakeBus
-
-    m = OVOSMPVService({}, bus=FakeBus())
-    m.load_track("https://INVALID")
-    m.play()
-    time.sleep(2)
-    m.stop()


### PR DESCRIPTION
self._started.wait() was blocking the mpv thread, the Event never got set which caused all tracks to skip. by using bus events we allow MPV monitor thread to continue and properly set self._started

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback initiation reliability by extending the start timeout from 3 to 5 seconds.
  - Resolved an issue that could block the MPV monitor thread during track end handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->