### PR TITLE
fix/Nonetype

### DIFF
--- a/ovos_plugin_mpv/__init__.py
+++ b/ovos_plugin_mpv/__init__.py
@@ -136,7 +136,7 @@ class OVOSMPVService(AudioBackend):
         getting the duration of the audio in milliseconds
         """
         if self.mpv:
-            return self.mpv.duration * 1000  # seconds to ms
+            return (self.mpv.duration or 0) * 1000  # seconds to ms
         return 0
 
     def get_track_position(self):
@@ -144,7 +144,7 @@ class OVOSMPVService(AudioBackend):
         get current position in milliseconds
         """
         if self.mpv:
-            return self.mpv.time_pos * 1000  # seconds to ms
+            return (self.mpv.time_pos or 0) * 1000  # seconds to ms
         return 0
 
     def set_track_position(self, milliseconds):


### PR DESCRIPTION
closes https://github.com/OpenVoiceOS/ovos-audio-plugin-mpv/issues/3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of audio track duration and position to prevent errors when values are `None`, ensuring smoother playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->