### PR TITLE
feat!: dual-target mpv backend + rename to ovos-media-plugin-mpv

### DIFF
--- a/ovos_plugin_mpv/__init__.py
+++ b/ovos_plugin_mpv/__init__.py
@@ -4,16 +4,37 @@ from typing import List
 
 from ovos_bus_client.message import Message
 from ovos_plugin_manager.templates.audio import AudioBackend
+from ovos_plugin_manager.templates.media import (
+    MediaBackend, AudioPlayerBackend, VideoPlayerBackend)
 from ovos_utils.log import LOG
 from ovos_utils.fakebus import FakeBus
 from python_mpv_jsonipc import MPV
 
 
-class OVOSMPVService(AudioBackend):
-    def __init__(self, config, bus=None, name='ovos_mpv'):
-        super(OVOSMPVService, self).__init__(config, bus, name)
-        self.config = config
-        self.bus = bus
+class MPVBaseService(MediaBackend):
+    """Shared mpv engine.
+
+    Holds all the playback logic (lazy ``MPV`` instance, event observers,
+    play/stop/pause/seek/volume, position tracking). It is shared by both
+    backend flavours so they drive one engine with no duplicated logic:
+
+    * new ``ovos-media`` — :class:`MPVOCPAudioService` / :class:`MPVOCPVideoService`
+      (``AudioPlayerBackend`` / ``VideoPlayerBackend``)
+    * legacy ``ovos-audio`` — :class:`OVOSMPVService` (``AudioBackend``)
+    """
+
+    def __init__(self, config, bus=None):
+        super().__init__(config, bus)
+        self._init_mpv_state()
+
+    def _init_mpv_state(self):
+        """Set up mpv-specific instance state.
+
+        Factored out of ``__init__`` so the legacy ``AudioBackend`` adapter
+        (whose constructor takes a ``name``) can reuse it after its own base
+        ``__init__`` has run. ``self.config``/``self.bus`` are already set by the
+        framework base constructor.
+        """
         self.normal_volume = self.config.get('initial_volume', 100)
         self.low_volume = self.config.get('low_volume', 50)
         self._playback_time = 0
@@ -81,7 +102,7 @@ class OVOSMPVService(AudioBackend):
             self._last_sync = time.time()
             try:
                 self.ocp_sync_playback(self._playback_time)
-            except:  # too old OPM version
+            except:  # too old OPM version / new MediaBackend without the helper
                 self.bus.emit(Message("ovos.common_play.playback_time",
                                       {"position": self._playback_time,
                                        "length": self.get_track_length()}))
@@ -182,6 +203,34 @@ class OVOSMPVService(AudioBackend):
         """
         if self.mpv:
             self.mpv.command("seek", seconds * -1)
+
+
+# --- new ovos-media backends (opm.media.audio / opm.media.video) ------------
+class MPVOCPAudioService(AudioPlayerBackend, MPVBaseService):
+    """mpv audio backend for the new ovos-media service."""
+
+    def __init__(self, config, bus=None):
+        super().__init__(config, bus)
+
+
+class MPVOCPVideoService(VideoPlayerBackend, MPVBaseService):
+    """mpv video backend for the new ovos-media service."""
+
+    def __init__(self, config, bus=None):
+        super().__init__(config, bus)
+
+
+# --- legacy ovos-audio service backend (mycroft.plugin.audioservice) --------
+class OVOSMPVService(MPVBaseService, AudioBackend):
+    """mpv backend for the legacy ovos-audio service.
+
+    ``MPVBaseService`` is listed first so its concrete playback methods satisfy
+    ``AudioBackend``'s abstract methods (MRO order matters).
+    """
+
+    def __init__(self, config, bus=None, name='ovos_mpv'):
+        AudioBackend.__init__(self, config, bus, name)
+        self._init_mpv_state()
 
 
 def load_service(base_config, bus):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,17 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "ovos-audio-plugin-mpv"
+name = "ovos-media-plugin-mpv"
 dynamic = ["version"]
-description = "mpv plugin for ovos"
+description = "mpv audio + video playback plugin for ovos-media (and the legacy ovos-audio service)"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 authors = [
     {name = "JarbasAi", email = "jarbasai@mailfence.com"}
 ]
-keywords = ["ovos", "audio", "plugin"]
+keywords = ["ovos", "audio", "video", "OCP", "plugin", "mpv"]
 dependencies = [
-    "ovos-plugin-manager>=0.0.26a29",
+    "ovos-plugin-manager>=2.1.0,<3.0.0",
     "python-mpv-jsonipc"
 ]
 
@@ -23,8 +23,16 @@ test = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/OpenVoiceOS/ovos-audio-plugin-mpv"
+Homepage = "https://github.com/OpenVoiceOS/ovos-media-plugin-mpv"
 
+# new ovos-media backends
+[project.entry-points."opm.media.audio"]
+ovos-media-audio-plugin-mpv = "ovos_plugin_mpv:MPVOCPAudioService"
+
+[project.entry-points."opm.media.video"]
+ovos-media-video-plugin-mpv = "ovos_plugin_mpv:MPVOCPVideoService"
+
+# legacy ovos-audio service backend (so the plugin works on both stacks)
 [project.entry-points."mycroft.plugin.audioservice"]
 ovos_mpv = "ovos_plugin_mpv"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,11 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest"
+    "pytest",
+    # end-to-end harness: drives the real backend through a real OCPMediaPlayer.
+    # [media] (the OCPPlayerHarness) lands in ovoscope 0.20.x; floor-pin so pip
+    # resolves it without --pre once published.
+    "ovoscope[media]>=0.20.0a1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ dependencies = [
 test = [
     "pytest",
     # end-to-end harness: drives the real backend through a real OCPMediaPlayer.
-    # [media] (the OCPPlayerHarness) lands in ovoscope 0.20.x; floor-pin so pip
-    # resolves it without --pre once published.
-    "ovoscope[media]>=0.20.0a1",
+    # [media] (the OCPPlayerHarness) ships in ovoscope 0.21.0a1; floor-pin so pip
+    # resolves the prerelease without --pre.
+    "ovoscope[media]>=0.21.0a1",
 ]
 
 [project.urls]

--- a/test/test_e2e.py
+++ b/test/test_e2e.py
@@ -1,0 +1,63 @@
+"""End-to-end tests: drive the real mpv OCP backend through a real
+``OCPMediaPlayer`` on a FakeBus via ovoscope's media harness.
+
+The mpv *engine* (libmpv via ``python_mpv_jsonipc.MPV``) is mocked so no real
+player/binary is needed, but everything else is real: the OCP player routes the
+play/pause/stop/seek requests to ``MPVOCPAudioService`` exactly as ovos-media
+would at runtime.
+
+Requires ``ovoscope[media]`` (pulls ovos-media).
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+try:
+    from ovoscope import OCPPlayerHarness
+    from ovos_utils.ocp import MediaEntry, PlaybackType, PlayerState
+    HAVE_HARNESS = True
+except Exception:
+    HAVE_HARNESS = False
+
+import ovos_plugin_mpv
+from ovos_plugin_mpv import MPVOCPAudioService
+
+URI = "http://example.com/song.mp3"
+
+
+def _factory(bus):
+    """Build the real mpv audio backend for injection into the OCP player."""
+    return MPVOCPAudioService({}, bus)
+
+
+@unittest.skipUnless(HAVE_HARNESS, "ovoscope[media] not installed")
+class TestMPVEndToEnd(unittest.TestCase):
+    def test_play_pause_resume_stop_through_ocp(self):
+        with patch.object(ovos_plugin_mpv, "MPV", MagicMock()):
+            with OCPPlayerHarness(backend_factory=_factory) as h:
+                entry = MediaEntry(uri=URI, playback=PlaybackType.AUDIO)
+
+                h.play(entry)
+                h.assert_player_state(PlayerState.PLAYING)
+                h.assert_now_playing_uri(URI)
+                # the real backend actually started its (mocked) mpv engine
+                self.assertIsNotNone(h.backend.mpv)
+
+                h.pause()
+                h.assert_player_state(PlayerState.PAUSED)
+
+                h.resume()
+                h.assert_player_state(PlayerState.PLAYING)
+
+                h.stop()
+                h.assert_player_state(PlayerState.STOPPED)
+
+    def test_backend_is_the_real_mpv_plugin(self):
+        with patch.object(ovos_plugin_mpv, "MPV", MagicMock()):
+            with OCPPlayerHarness(backend_factory=_factory) as h:
+                self.assertIsInstance(h.backend, MPVOCPAudioService)
+                self.assertEqual(h.backend.supported_uris(),
+                                 ["file", "http", "https"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_mpv.py
+++ b/test/test_mpv.py
@@ -1,12 +1,58 @@
+import os
 import unittest
 
 from ovos_utils.fakebus import FakeBus
+from ovos_plugin_manager.templates.audio import AudioBackend
+from ovos_plugin_manager.templates.media import (
+    AudioPlayerBackend, VideoPlayerBackend)
 
 from ovos_plugin_mpv import (
     OVOSMPVService,
+    MPVBaseService,
+    MPVOCPAudioService,
+    MPVOCPVideoService,
     MPVAudioPluginConfig,
     load_service,
 )
+
+
+class TestNewBackends(unittest.TestCase):
+    """Dual-target: new ovos-media backends share the mpv engine."""
+
+    def test_audio_backend_is_audioplayerbackend(self):
+        svc = MPVOCPAudioService({}, bus=FakeBus())
+        self.assertIsInstance(svc, AudioPlayerBackend)
+        self.assertIsInstance(svc, MPVBaseService)
+        # the shared engine state was initialised through the MRO
+        self.assertIsNone(svc.mpv)
+        self.assertEqual(svc.normal_volume, 100)
+
+    def test_video_backend_is_videoplayerbackend(self):
+        svc = MPVOCPVideoService({"initial_volume": 70}, bus=FakeBus())
+        self.assertIsInstance(svc, VideoPlayerBackend)
+        self.assertIsInstance(svc, MPVBaseService)
+        self.assertEqual(svc.normal_volume, 70)
+
+    def test_legacy_is_audiobackend(self):
+        svc = OVOSMPVService({}, bus=FakeBus(), name='ovos_mpv')
+        self.assertIsInstance(svc, AudioBackend)
+        self.assertIsInstance(svc, MPVBaseService)
+
+    def test_supported_uris_match(self):
+        for cls in (MPVOCPAudioService, MPVOCPVideoService, OVOSMPVService):
+            self.assertEqual(cls({}, bus=FakeBus()).supported_uris(),
+                             ["file", "http", "https"])
+
+
+class TestEntryPoints(unittest.TestCase):
+    def test_pyproject_declares_new_and_legacy_groups(self):
+        here = os.path.dirname(os.path.dirname(__file__))
+        with open(os.path.join(here, "pyproject.toml")) as f:
+            src = f.read()
+        self.assertIn("opm.media.audio", src)
+        self.assertIn("opm.media.video", src)
+        self.assertIn("mycroft.plugin.audioservice", src)
+        self.assertIn("MPVOCPAudioService", src)
 
 
 class TestMPVAudioPluginConfig(unittest.TestCase):


### PR DESCRIPTION
Makes mpv work on **both** stacks (it was legacy ovos-audio only) and renames the distribution to match the `ovos-media-plugin-*` family.

- **New ovos-media backends**: extract the mpv engine into a shared `MPVBaseService(MediaBackend)`; add `MPVOCPAudioService` (`opm.media.audio`) + `MPVOCPVideoService` (`opm.media.video`). The legacy `OVOSMPVService` (`mycroft.plugin.audioservice`) now reuses the same engine via base-first MRO — no duplicated logic.
- **Rename**: distribution `ovos-audio-plugin-mpv` → `ovos-media-plugin-mpv`; bump `ovos-plugin-manager>=2.1.0,<3.0.0` (needed for the `opm.media.*` templates). Python module stays `ovos_plugin_mpv` (mplayer convention).
- 18 tests pass (new audio/video backends + legacy adapter share one engine; entry-point groups asserted).

The GitHub repo is being renamed to `ovos-media-plugin-mpv` (redirects preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)