### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,20 @@
-# MPV OVOS Plugin
+# ovos-media-plugin-mpv
 
-The MPV OVOS Plugin integrates MPV media player capabilities with the Open Voice OS (OVOS) ecosystem, providing an audio backend for playing various media formats.
+`ovos-media-plugin-mpv` is an audio and video playback plugin for [OpenVoiceOS](https://github.com/OpenVoiceOS) (OVOS). It drives the [mpv](https://mpv.io) media player through `python-mpv-jsonipc` and exposes it as a playback backend for [ovos-media](https://github.com/OpenVoiceOS/ovos-media) and the legacy `ovos-audio` service.
 
-## Features
+## Install
 
-- Supports playback of various audio formats.
-- Provides basic playback controls: play, pause, stop, resume, seek forward, seek backward.
-- Volume management with automatic volume adjustments.
-- Integration with OVOS for media playback 
+Install the plugin with pip:
 
-## Prerequisites
+```bash
+pip install ovos-media-plugin-mpv
+```
 
-Ensure you have the following installed on your system:
-- Python 3.6 or higher
-- MPV media player
-- Open Voice OS (OVOS) components
+The plugin needs the `mpv` media player installed and available on the system.
 
+## Usage
 
-## Configuration
-
-The MPV OVOS Plugin configuration can be set in your OVOS configuration file. Here is an example configuration:
+OVOS discovers the plugin through entry points, so no code changes are needed. Enable and configure it in your OVOS configuration file:
 
 ```json
 {
@@ -34,32 +29,29 @@ The MPV OVOS Plugin configuration can be set in your OVOS configuration file. He
 }
 ```
 
-## Usage
+`initial_volume` sets the starting volume. `low_volume` sets the volume used while the assistant lowers playback, for example to speak over a track.
 
-The plugin integrates with OVOS to handle audio playback. It supports the following functions:
+The plugin registers under two entry-point groups, so it works with both stacks:
 
-- **play(repeat=False):** Play the current track.
-- **stop():** Stop playback.
-- **pause():** Pause playback.
-- **resume():** Resume paused playback.
-- **lower_volume():** Lower the volume to a predefined level.
-- **restore_volume():** Restore the volume to the original level.
-- **track_info():** Get information about the current track.
-- **get_track_length():** Get the duration of the current track in milliseconds.
-- **get_track_position():** Get the current playback position in milliseconds.
-- **set_track_position(milliseconds):** Set the playback position in milliseconds.
-- **seek_forward(seconds=1):** Seek forward by a specified number of seconds.
-- **seek_backward(seconds=1):** Seek backward by a specified number of seconds.
+- `opm.media.audio` / `opm.media.video`, used by the current `ovos-media` service.
+- `mycroft.plugin.audioservice`, used by the legacy `ovos-audio` service.
 
+Once active, the backend exposes the standard OVOS media-backend API: play, stop, pause, resume, seek forward, seek backward, track position, and track length.
 
 ## Troubleshooting
 
-If you encounter any issues, ensure that:
-- MPV is correctly installed and accessible.
-- The plugin is installed.
-- Your configuration file is correctly set up.
-- If using containers ensure it is installed in `ovos-audio` container
+- Confirm mpv is installed and runs directly from the command line.
+- Confirm the plugin package is installed in the same environment as the OVOS service (in containers, install it inside the `ovos-audio` container).
+- Confirm the backend is active in the configuration file.
+- Check the service logs. If a stream does not play, confirm the stream plays directly in mpv.
 
-For further assistance, refer to the official documentation or contact the plugin maintainers.
+## Related projects
 
-Check the logs to see what is happening, if specific streams are not playing verify that they play directly in MPV
+- [OpenVoiceOS/ovos-media](https://github.com/OpenVoiceOS/ovos-media), the media service that loads this backend.
+- [OpenVoiceOS/ovos-media-plugin-vlc](https://github.com/OpenVoiceOS/ovos-media-plugin-vlc), a sibling backend that uses VLC.
+- [OpenVoiceOS/ovos-media-plugin-ffplay](https://github.com/OpenVoiceOS/ovos-media-plugin-ffplay), a sibling backend that uses ffplay.
+- [OpenVoiceOS/ovos-media-plugin-mplayer](https://github.com/OpenVoiceOS/ovos-media-plugin-mplayer), a sibling backend that uses mplayer.
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
Rewrites the README for clarity: adds a plain description, an install section, a usage section explaining the two entry-point groups (new ovos-media backend and legacy ovos-audio backend), and a related-projects section linking sibling media backends in the OpenVoiceOS org. All facts are unchanged from the original text and the plugin code.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the README with concise guidance on the plugin’s purpose, installation, prerequisites, configuration, compatibility, supported backend API, troubleshooting, related projects, and licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->